### PR TITLE
generate from multiple JSON Schema inputs, resolving cross-input refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Generates Go (golang) Structs from JSON schema.
 Run this:
 
 ```bash
-go run main.go -i exampleschema.json
+go run main.go exampleschema.json
 ```
 
 Get this:
@@ -128,4 +128,3 @@ type Status struct {
   Favouritecat string `json:"favouritecat,omitempty"`
 }
 ```
-

--- a/cmd/schema-generate/main.go
+++ b/cmd/schema-generate/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		if jsonError, ok := err.(*json.SyntaxError); ok {
 			line, character, lcErr := lineAndCharacter(b, int(jsonError.Offset))
-			fmt.Fprintf(os.Stderr, "Cannot parse JSON schema due to a syntax error at line %d, character %d: %v\n", line, character, jsonError.Error())
+			fmt.Fprintf(os.Stderr, "Cannot parse JSON schema due to a syntax error at %s line %d, character %d: %v\n", *i, line, character, jsonError.Error())
 			if lcErr != nil {
 				fmt.Fprintf(os.Stderr, "Couldn't find the line and character position of the error due to error %v\n", lcErr)
 			}
@@ -43,13 +43,13 @@ func main() {
 		}
 		if jsonError, ok := err.(*json.UnmarshalTypeError); ok {
 			line, character, lcErr := lineAndCharacter(b, int(jsonError.Offset))
-			fmt.Fprintf(os.Stderr, "The JSON type '%v' cannot be converted into the Go '%v' type on struct '%s', field '%v'. See input file line %d, character %d\n", jsonError.Value, jsonError.Type.Name(), jsonError.Struct, jsonError.Field, line, character)
+			fmt.Fprintf(os.Stderr, "The JSON type '%v' cannot be converted into the Go '%v' type on struct '%s', field '%v'. See input file %s line %d, character %d\n", jsonError.Value, jsonError.Type.Name(), jsonError.Struct, jsonError.Field, *i, line, character)
 			if lcErr != nil {
 				fmt.Fprintf(os.Stderr, "Couldn't find the line and character position of the error due to error %v\n", lcErr)
 			}
 			return
 		}
-		fmt.Fprintln(os.Stderr, "Failed to parse the input JSON schema with error ", err)
+		fmt.Fprintf(os.Stderr, "Failed to parse the input JSON schema file %s with error %v\n", *i, err)
 		return
 	}
 

--- a/cmd/schema-generate/main.go
+++ b/cmd/schema-generate/main.go
@@ -15,45 +15,58 @@ import (
 )
 
 var (
-	i = flag.String("i", "", "The input JSON Schema file.")
 	o = flag.String("o", "", "The output file for the schema.")
 	p = flag.String("p", "main", "The package that the structs are created in.")
 )
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintln(os.Stderr, "  paths")
+		fmt.Fprintln(os.Stderr, "\tThe input JSON Schema files.")
+	}
+
 	flag.Parse()
 
-	b, err := ioutil.ReadFile(*i)
-
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Failed to read the input file with error ", err)
-		return
+	inputFiles := flag.Args()
+	if len(inputFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "No input JSON Schema files.")
+		os.Exit(1)
 	}
 
-	schema, err := jsonschema.Parse(string(b))
+	schemas := make([]*jsonschema.Schema, len(inputFiles))
+	for i, file := range inputFiles {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to read the input file with error ", err)
+			return
+		}
 
-	if err != nil {
-		if jsonError, ok := err.(*json.SyntaxError); ok {
-			line, character, lcErr := lineAndCharacter(b, int(jsonError.Offset))
-			fmt.Fprintf(os.Stderr, "Cannot parse JSON schema due to a syntax error at %s line %d, character %d: %v\n", *i, line, character, jsonError.Error())
-			if lcErr != nil {
-				fmt.Fprintf(os.Stderr, "Couldn't find the line and character position of the error due to error %v\n", lcErr)
+		schemas[i], err = jsonschema.Parse(string(b))
+		if err != nil {
+			if jsonError, ok := err.(*json.SyntaxError); ok {
+				line, character, lcErr := lineAndCharacter(b, int(jsonError.Offset))
+				fmt.Fprintf(os.Stderr, "Cannot parse JSON schema due to a syntax error at %s line %d, character %d: %v\n", file, line, character, jsonError.Error())
+				if lcErr != nil {
+					fmt.Fprintf(os.Stderr, "Couldn't find the line and character position of the error due to error %v\n", lcErr)
+				}
+				return
 			}
+			if jsonError, ok := err.(*json.UnmarshalTypeError); ok {
+				line, character, lcErr := lineAndCharacter(b, int(jsonError.Offset))
+				fmt.Fprintf(os.Stderr, "The JSON type '%v' cannot be converted into the Go '%v' type on struct '%s', field '%v'. See input file %s line %d, character %d\n", jsonError.Value, jsonError.Type.Name(), jsonError.Struct, jsonError.Field, file, line, character)
+				if lcErr != nil {
+					fmt.Fprintf(os.Stderr, "Couldn't find the line and character position of the error due to error %v\n", lcErr)
+				}
+				return
+			}
+			fmt.Fprintf(os.Stderr, "Failed to parse the input JSON schema file %s with error %v\n", file, err)
 			return
 		}
-		if jsonError, ok := err.(*json.UnmarshalTypeError); ok {
-			line, character, lcErr := lineAndCharacter(b, int(jsonError.Offset))
-			fmt.Fprintf(os.Stderr, "The JSON type '%v' cannot be converted into the Go '%v' type on struct '%s', field '%v'. See input file %s line %d, character %d\n", jsonError.Value, jsonError.Type.Name(), jsonError.Struct, jsonError.Field, *i, line, character)
-			if lcErr != nil {
-				fmt.Fprintf(os.Stderr, "Couldn't find the line and character position of the error due to error %v\n", lcErr)
-			}
-			return
-		}
-		fmt.Fprintf(os.Stderr, "Failed to parse the input JSON schema file %s with error %v\n", *i, err)
-		return
 	}
 
-	g := generate.New(schema)
+	g := generate.New(schemas...)
 
 	structs, err := g.CreateStructs()
 


### PR DESCRIPTION
Supports generating a Go file with the types from multiple JSON Schema input files at once. This also fixes #9 by resolving refs to types in other input files. (It's still unsupported to refer to things not in any of the input files.)