### PR TITLE
Fix array with title undefined symbol

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -280,6 +280,10 @@ func getPrimitiveTypeName(schemaType string, subType string, pointer bool) (name
 // getStructName makes a golang struct name from an input reference in the form of #/definitions/address
 // The parts refers to the number of segments from the end to take as the name.
 func getStructName(reference *url.URL, structType *jsonschema.Schema, n int) string {
+	if len(structType.Title) > 0 {
+		return getGolangName(structType.Title)
+	}
+
 	if reference.Fragment == "" {
 		rootName := structType.Title
 

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -95,13 +95,6 @@ func addTypeAndChildrenToMap(path string, name string, s *Schema, types map[stri
 	if t == "array" {
 		arrayTypeName := s.ID
 
-		// If there's no ID, try the title instead.
-		if arrayTypeName == "" {
-			if s.Items != nil {
-				arrayTypeName = s.Items.Title
-			}
-		}
-
 		// If there's no title, use the property name to name the type we're creating.
 		if arrayTypeName == "" {
 			arrayTypeName = name


### PR DESCRIPTION
Here is my json schema.

```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "type": "object",
    "title": "PingPong",
    "properties": {
        "pings": {
            "type": "array",
            "items": {
                "type": "object",
                "title": "Ping", 
                "description": "Ping description", 
                "properties": {
                    "id": {
                        "type": "string",
                        "description": "ID"
                    }
                }
            }
        },
        "pongs": {
            "type": "array",
            "items": {
                "type": "object",
                "title": "Pong", 
                "description": "Pong description", 
                "properties": {
                    "id": {
                        "type": "string",
                        "description": "ID"
                    }
                }
            }
        }
    }
}
```

**Expected output**:
```go
// Ping Ping description
type Ping struct {
  Id string `json:"id,omitempty"`
}

// PingPong 
type PingPong struct {
  Pings []Ping `json:"pings,omitempty"`
  Pongs []Pong `json:"pongs,omitempty"`
}

// Pong Pong description
type Pong struct {
  Id string `json:"id,omitempty"`
}
```

**Actual result**:
```go
// Ping Ping description
type Ping struct {
  Id string `json:"id,omitempty"`
}

// PingPong 
type PingPong struct {
  Pings []undefined `json:"pings,omitempty"` // <---------------- undefined?
  Pongs []undefined `json:"pongs,omitempty"` // <---------------- undefined?
}

// Pong Pong description
type Pong struct {
  Id string `json:"id,omitempty"`
}
```

If I remove `"title": "Ping"` and `"title":"Pong"` from json schema then I got below structs:
```go
// PingPong 
type PingPong struct {
  Pings []Pings `json:"pings,omitempty"`   // <-------- strange name for an object Pings
  Pongs []Pongs `json:"pongs,omitempty"` // <-------- same here Pongs
}

// Pings Ping description
type Pings struct {
  Id string `json:"id,omitempty"`
}

// Pongs Pong description
type Pongs struct {
  Id string `json:"id,omitempty"`
}
```

This patch fixes above errors and for struct name uses given `title` inside array item, if no title is given fallback to old solution and use name from `properties`, for the variable naming of an array inside the object (PingPong in this case) uses name given in `properties` of object