### PR TITLE
Fix array with title undefined symbol (part 2)

### DIFF
--- a/cmd/issue35.json
+++ b/cmd/issue35.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "PingPong",
+    "properties": {
+        "pings": {
+            "type": "array",
+            "items": {
+                "title": "Ping",
+                "description": "Ping description",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "ID"
+                    }
+                }
+            }
+        },
+        "pongs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "Pong",
+                "description": "Pong description",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "ID"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/generator.go
+++ b/generator.go
@@ -281,6 +281,10 @@ func getPrimitiveTypeName(schemaType string, subType string, pointer bool) (name
 // getStructName makes a golang struct name from an input reference in the form of #/definitions/address
 // The parts refers to the number of segments from the end to take as the name.
 func getStructName(reference *url.URL, structType *jsonschema.Schema, n int) string {
+	if len(structType.Title) > 0 {
+		return getGolangName(structType.Title)
+	}
+
 	if reference.Fragment == "" {
 		rootName := structType.Title
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -355,7 +355,8 @@ func TestNestedArrayGeneration(t *testing.T) {
 			"cities": {
 				TypeValue: "array",
 				Items: &jsonschema.Schema{
-					Title: "City",
+					Title:     "City",
+					TypeValue: "object",
 					Properties: map[string]*jsonschema.Schema{
 						"name":    {TypeValue: "string"},
 						"country": {TypeValue: "string"},
@@ -381,7 +382,6 @@ func TestNestedArrayGeneration(t *testing.T) {
 	}
 
 	fbStruct, ok := results["FavouriteBars"]
-
 	if !ok {
 		t.Errorf("FavouriteBars struct was not found. The results were %+v", results)
 	}
@@ -390,24 +390,24 @@ func TestNestedArrayGeneration(t *testing.T) {
 		t.Errorf("Expected to find the BarName field, but didn't. The struct is %+v", fbStruct)
 	}
 
-	if f, ok := fbStruct.Fields["Cities"]; !ok {
+	f, ok := fbStruct.Fields["Cities"]
+	if !ok {
 		t.Errorf("Expected to find the Cities field on the FavouriteBars, but didn't. The struct is %+v", fbStruct)
-
-		if f.Type != "City" {
-			t.Errorf("Expected to find that the Cities array was of type City, but it was of %s", f.Type)
-		}
+	}
+	if f.Type != "[]City" {
+		t.Errorf("Expected to find that the Cities array was of type City, but it was of %s", f.Type)
 	}
 
-	if f, ok := fbStruct.Fields["Tags"]; !ok {
+	f, ok = fbStruct.Fields["Tags"]
+	if !ok {
 		t.Errorf("Expected to find the Tags field on the FavouriteBars, but didn't. The struct is %+v", fbStruct)
+	}
 
-		if f.Type != "array" {
-			t.Errorf("Expected to find that the Tags array was of type array, but it was of %s", f.Type)
-		}
+	if f.Type != "[]string" {
+		t.Errorf("Expected to find that the Tags array was of type string, but it was of %s", f.Type)
 	}
 
 	cityStruct, ok := results["City"]
-
 	if !ok {
 		t.Error("City struct was not found.")
 	}

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -96,13 +96,6 @@ func addTypeAndChildrenToMap(path string, name string, s *Schema, types map[stri
 	if t == "array" {
 		arrayTypeName := s.ID
 
-		// If there's no ID, try the title instead.
-		if arrayTypeName == "" {
-			if s.Items != nil {
-				arrayTypeName = s.Items.Title
-			}
-		}
-
 		// If there's no title, use the property name to name the type we're creating.
 		if arrayTypeName == "" {
 			arrayTypeName = name

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -96,7 +96,7 @@ func addTypeAndChildrenToMap(path string, name string, s *Schema, types map[stri
 	if t == "array" {
 		arrayTypeName := s.ID
 
-		// If there's no title, use the property name to name the type we're creating.
+		// If there's no ID, use the property name to name the type we're creating.
 		if arrayTypeName == "" {
 			arrayTypeName = name
 		}

--- a/jsonschema/jsonschemaparse_test.go
+++ b/jsonschema/jsonschemaparse_test.go
@@ -1,7 +1,6 @@
 package jsonschema
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -336,27 +335,29 @@ func TestThatArraysAreSupported(t *testing.T) {
 	// Check that the types can be extracted into a map.
 	types := so.ExtractTypes()
 
-	fmt.Printf("Types: %+v\n", types)
-
 	if len(types) != 1 {
 		t.Errorf("expected 1 type, just the Product, but got %d types - %s", len(types),
 			strings.Join(getKeyNames(types), ", "))
 	}
 
-	// Check that the names of the types map to expected references.
-	ps, ok := types["#/Product"]
+	// Check that the path of the types map to expected references.
+	ps, ok := types["#"]
 	if !ok {
-		t.Fatalf("was expecting to find the Product type but available types were %s",
+		t.Fatalf("Expected to find the '#' schema path, but available paths were %s",
 			strings.Join(getKeyNames(types), ", "))
 	}
 
+	if ps.Title != "Product" {
+		t.Errorf("Expected the root schema's title to be 'Product', but it was %s", ps.Title)
+	}
+
 	if len(ps.Properties) != 4 {
-		t.Errorf("was expecting the Product to have 4 properties, but it had %d", len(ps.Properties))
+		t.Errorf("Expected the Product schema to have 4 properties, but it had %d", len(ps.Properties))
 	}
 
 	tagType, _ := ps.Properties["tags"].Type()
 	if tagType != "array" {
-		t.Errorf("expected the 'Tags' property type to be 'array', but it was %s", tagType)
+		t.Errorf("Expected the Tags property type to be 'array', but it was %s", tagType)
 	}
 }
 


### PR DESCRIPTION
Closes #35

Address issues from previous PR:

- fix array tests
- rephrase comment in `addTypeAndChildrenToMap()`

:arrow_right: [**Tests result**](https://travis-ci.org/antoineco/generate/builds/358033426)

---

NOTE: adding `"type": "object"` to array items is mandatory, otherwise the type remains `[]undefined` (see `issue35.json`). This is fairly minor though.

`❯ ./schema-generate cmd/issue35.json | gofmt`
```golang
// ...

// PingPong
type PingPong struct {
	Pings []undefined `json:"pings,omitempty"`  // no `"type"` keyword
	Pongs []Pong      `json:"pongs,omitempty"`  // `"type": "object"`
}

// ...
```