### PR TITLE
Generate pointer type for array of objects

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -224,7 +224,7 @@ func getTypeForField(parentTypeKey *url.URL, fieldName string, fieldGoName strin
 
 	// Find named array references.
 	if majorType == "array" {
-		s, _ := getTypeForField(parentTypeKey, fieldName, fieldGoName, fieldSchema.Items, types, false)
+		s, _ := getTypeForField(parentTypeKey, fieldName, fieldGoName, fieldSchema.Items, types, true)
 		subType = s
 	}
 
@@ -268,7 +268,6 @@ func getPrimitiveTypeName(schemaType string, subType string, pointer bool) (name
 		if pointer {
 			return "*" + subType, nil
 		}
-
 		return subType, nil
 	case "string":
 		return "string", nil

--- a/generator_test.go
+++ b/generator_test.go
@@ -158,7 +158,7 @@ func TestFieldGenerationWithArrayReferences(t *testing.T) {
 	}
 
 	testField(result["Property1"], "property1", "Property1", "string", false, t)
-	testField(result["Property2"], "property2", "Property2", "[]Address", true, t)
+	testField(result["Property2"], "property2", "Property2", "[]*Address", true, t)
 	testField(result["Property3"], "property3", "Property3", "[]map[string]int", false, t)
 }
 
@@ -394,8 +394,8 @@ func TestNestedArrayGeneration(t *testing.T) {
 	if !ok {
 		t.Errorf("Expected to find the Cities field on the FavouriteBars, but didn't. The struct is %+v", fbStruct)
 	}
-	if f.Type != "[]City" {
-		t.Errorf("Expected to find that the Cities array was of type City, but it was of %s", f.Type)
+	if f.Type != "[]*City" {
+		t.Errorf("Expected to find that the Cities array was of type *City, but it was of %s", f.Type)
 	}
 
 	f, ok = fbStruct.Fields["Tags"]


### PR DESCRIPTION
Currently, pointer types are generated for `struct` fields, but non-pointer types are generated for arrays of `struct`.

**Example:**

The following JSON schema...

```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "title": "Array Of Objects",
    "properties": {
        "singleobject": {
                "type": "object"
        },
        "multipleobjects": {
            "type": "array",
            "items": {
                "type": "object"
            }
        }
    }
}
```

...generates the following structs:

```golang
// Code generated by schema-generate. DO NOT EDIT.

package main

// ArrayOfObjects
type ArrayOfObjects struct {
	Multipleobjects []Multipleobjects `json:"multipleobjects,omitempty"`
	Singleobject    *Singleobject     `json:"singleobject,omitempty"`
}

// Multipleobjects
type Multipleobjects struct {
}

// Singleobject
type Singleobject struct {
}
```

**After this PR:**

Arrays of `struct` are effectively pointer types:

```golang
// ...


// ArrayOfObjects
type ArrayOfObjects struct {
	Multipleobjects []*Multipleobjects `json:"multipleobjects,omitempty"`
	Singleobject    *Singleobject      `json:"singleobject,omitempty"`
}

// ...
```

➡️ [**Tests result**](https://travis-ci.org/antoineco/generate/builds/362073630)