### PR TITLE
Support no schema key

### DIFF
--- a/cmd/schema-generate/main.go
+++ b/cmd/schema-generate/main.go
@@ -149,14 +149,8 @@ func output(w io.Writer, structs map[string]generate.Struct) {
 	for _, k := range getOrderedStructNames(structs) {
 		s := structs[k]
 
-		desc := s.Description
-
-		if desc == "" {
-			desc = "(No description)"
-		}
-
 		fmt.Fprintln(w, "")
-		fmt.Fprintf(w, "// %s: %s\n", s.Name, desc)
+		fmt.Fprintf(w, "// %s %s\n", s.Name, s.Description)
 		fmt.Fprintf(w, "type %s struct {\n", s.Name)
 
 		for _, fieldKey := range getOrderedFieldNames(s.Fields) {

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -53,7 +53,7 @@ func (s *Schema) Type() (firstOrDefault string, multiple bool) {
 }
 
 // Parse parses a JSON schema from a string.
-func Parse(schema string) (*Schema, error) {
+func Parse(schema string, nsk bool) (*Schema, error) {
 	s := &Schema{}
 	err := json.Unmarshal([]byte(schema), s)
 
@@ -61,8 +61,8 @@ func Parse(schema string) (*Schema, error) {
 		return s, err
 	}
 
-	if s.SchemaType == "" {
-		return s, errors.New("JSON schema must have a $schema key")
+	if !nsk && s.SchemaType == "" {
+		return s, errors.New("JSON schema must have a $schema key unless -nsk flag is set")
 	}
 
 	return s, err

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -52,8 +52,8 @@ func (s *Schema) Type() (firstOrDefault string, multiple bool) {
 	return "", multiple
 }
 
-// Parse parses a JSON schema from a string.
-func Parse(schema string, nsk bool) (*Schema, error) {
+// Parse parses a JSON schema from a string, with an optional boolean argument to permit schemas without a $schema key.
+func Parse(schema string, nsk ...bool) (*Schema, error) {
 	s := &Schema{}
 	err := json.Unmarshal([]byte(schema), s)
 
@@ -61,8 +61,8 @@ func Parse(schema string, nsk bool) (*Schema, error) {
 		return s, err
 	}
 
-	if !nsk && s.SchemaType == "" {
-		return s, errors.New("JSON schema must have a $schema key unless -nsk flag is set")
+	if (len(nsk) == 0 || nsk[0] == false) && s.SchemaType == "" {
+		return s, errors.New("JSON schema must have a $schema key unless nsk flag is set")
 	}
 
 	return s, err

--- a/jsonschema/jsonschemaparse_test.go
+++ b/jsonschema/jsonschemaparse_test.go
@@ -461,7 +461,7 @@ func TestThatRequiredPropertiesAreIncludedInTheSchemaModel(t *testing.T) {
         }
     }
 }`
-	so, err := Parse(s, false)
+	so, err := Parse(s)
 
 	if err != nil {
 		t.Error("failed to parse the test JSON: ", err)
@@ -494,7 +494,7 @@ func TestThatPropertiesCanHaveMultipleTypes(t *testing.T) {
             }
         }
     }`
-	so, err := Parse(s, false)
+	so, err := Parse(s)
 
 	if err != nil {
 		t.Error("It was not possible to deserialize the schema with references with error ", err)

--- a/jsonschema/jsonschemaparse_test.go
+++ b/jsonschema/jsonschemaparse_test.go
@@ -29,6 +29,19 @@ func TestThatAMissingSchemaKeyResultsInAnError(t *testing.T) {
 	}
 }
 
+func TestThatAMissingSchemaKeyResultsInNoErrorIfNoKeySet(t *testing.T) {
+	invalid := `{
+        "title": "root"
+    }`
+
+	_, invaliderr := Parse(invalid, true)
+
+	if invaliderr != nil {
+		t.Error("When the argument to allow schemas without a $schema key is set, the JSON Schema should parse without a $schema key")
+	}
+
+}
+
 func TestThatTheRootSchemaCanBeParsed(t *testing.T) {
 	s := `{
         "$schema": "http://json-schema.org/schema#",
@@ -448,7 +461,7 @@ func TestThatRequiredPropertiesAreIncludedInTheSchemaModel(t *testing.T) {
         }
     }
 }`
-	so, err := Parse(s)
+	so, err := Parse(s, false)
 
 	if err != nil {
 		t.Error("failed to parse the test JSON: ", err)
@@ -481,7 +494,7 @@ func TestThatPropertiesCanHaveMultipleTypes(t *testing.T) {
             }
         }
     }`
-	so, err := Parse(s)
+	so, err := Parse(s, false)
 
 	if err != nil {
 		t.Error("It was not possible to deserialize the schema with references with error ", err)


### PR DESCRIPTION
Unfortunately some JSON schema, in particular the Swagger definitions which can exported from AWS API Gateway do not contain a $schema key. This PR allows the generation of Golang models from JSON schema of this type by adding a command line switch and an additional optional argument to the jsonschema.Parse function to allow schema without a $schema key.