### PR TITLE
Allow underscore to exist at beginning of type name

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -327,6 +327,12 @@ func (g *Generator) getSchemaName(keyName string, schema *Schema) string {
 // getGolangName strips invalid characters out of golang struct or field names.
 func getGolangName(s string) string {
 	buf := bytes.NewBuffer([]byte{})
+
+	if s[0] == '_' {
+		// Go variables are allowed to start with an underscore and an underscore at the beginning does not indicate snake_casing
+		buf.WriteRune('_')
+	}
+
 	for i, v := range splitOnAll(s, isNotAGoNameCharacter) {
 		if i == 0 && strings.IndexAny(v, "0123456789") == 0 {
 			// Go types are not allowed to start with a number, lets prefix with an underscore.

--- a/generator_test.go
+++ b/generator_test.go
@@ -520,9 +520,14 @@ func TestThatJavascriptKeyNamesCanBeConvertedToValidGoNames(t *testing.T) {
 			expected:    "KeyName",
 		},
 		{
-			description: "Underscores are stripped.",
+			description: "Underscores are stripped in mid sentence.",
 			input:       "key_name",
 			expected:    "KeyName",
+		},
+		{
+			description: "Underscores at the beginning are preserved.",
+			input:       "_key",
+			expected:    "_Key",
 		},
 		{
 			description: "Periods are stripped.",


### PR DESCRIPTION
getGolangName currently splits on underscore and converts snake_case to CamelCase. According to Golang spec: https://golang.org/ref/spec#Letters_and_digits, underscore are allowed at the beginning of a type.

In the health care world, the fhir json schema extensively uses underscores to define the extension json property of the equally named simple json property.

This PR allows underscore at the beginning to remain.