### PR TITLE
Add support for named-type default values.

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -197,8 +197,9 @@ func (g *Generator) processObject(name string, schema *Schema) (typ string, err 
 			Type:        fieldType,
 			Required:    contains(schema.Required, propKey),
 			Description: prop.Description,
+			Default:     prop.Default,
 		}
-		if f.Required {
+		if f.Required || f.Default != nil {
 			strct.GenerateCode = true
 		}
 		strct.Fields[f.Name] = f
@@ -396,4 +397,5 @@ type Field struct {
 	// Required is set to true when the field is required.
 	Required    bool
 	Description string
+	Default     interface{}
 }

--- a/output.go
+++ b/output.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"sort"
 	"strings"
 )
@@ -196,6 +197,19 @@ func (strct *%s) UnmarshalJSON(b []byte) error {
     if err := json.Unmarshal(b, &jsonMap); err != nil {
         return err
     }`)
+
+	// set initial field values to their defaults if defined.
+	fmt.Fprintf(w, `
+    // apply default values
+`)
+	for _, fieldKey := range getOrderedFieldNames(s.Fields) {
+		f := s.Fields[fieldKey]
+		if f.JSONName == "-" || f.Default == nil || reflect.TypeOf(f.Default).Name() == "" {
+			continue
+		}
+		fmt.Fprintf(w, `    strct.%s = %#v;
+`, f.Name, f.Default)
+	}
 
 	// figure out if we need the "v" output of the range keyword
 	needVal := "_"

--- a/test/defaultValues.json
+++ b/test/defaultValues.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://thing",
+
+  "type": "object",
+
+  "properties": {
+    "name": {
+      "type": "string",
+      "default": "Unnamed"
+    },
+    "age": {
+      "type": "integer",
+      "default": -1
+    },
+    "score": {
+      "type": "number",
+      "default": -1.0
+    }
+  }
+}

--- a/test/defaultValues_test.go
+++ b/test/defaultValues_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"testing"
+
+	defaultValues "github.com/a-h/generate/test/defaultValues_gen"
+)
+
+func TestDefaultValues(t *testing.T) {
+	result := &defaultValues.Root{}
+	result.UnmarshalJSON([]byte("{}"))
+	if result.Name != "Unnamed" {
+		t.Errorf("Object had unexpected name \"%s\".", result.Name)
+	}
+	if result.Age != -1 {
+		t.Errorf("Object had unexpected name \"%d\".", result.Age)
+	}
+	if result.Score != -1.0 {
+		t.Errorf("Object had unexpected score \"%f\".", result.Score)
+	}
+}


### PR DESCRIPTION
This adds some primitive support for handling default values when unmarshalling JSON. The main limitation is that it only supports named-types (e.g. it won't work if the default value is a JSON array), but hopefully this is still useful in many cases, such as when a field has a default value of -1.