### PR TITLE
Names with dashes in them aren't valid golang variables; just use the f.Name instead.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/a-h/generate
+
+go 1.16

--- a/output.go
+++ b/output.go
@@ -188,7 +188,7 @@ func (strct *%s) UnmarshalJSON(b []byte) error {
 	for _, fieldKey := range getOrderedFieldNames(s.Fields) {
 		f := s.Fields[fieldKey]
 		if f.Required {
-			fmt.Fprintf(w, "    %sReceived := false\n", f.JSONName)
+			fmt.Fprintf(w, "    %sReceived := false\n", f.Name)
 		}
 	}
 	// setup initial unmarshal
@@ -220,7 +220,7 @@ func (strct *%s) UnmarshalJSON(b []byte) error {
              }
 `, f.JSONName, f.Name)
 		if f.Required {
-			fmt.Fprintf(w, "            %sReceived = true\n", f.JSONName)
+			fmt.Fprintf(w, "            %sReceived = true\n", f.Name)
 		}
 	}
 
@@ -258,7 +258,7 @@ func (strct *%s) UnmarshalJSON(b []byte) error {
     if !%sReceived {
         return errors.New("\"%s\" is required but was not present")
     }
-`, f.JSONName, f.JSONName, f.JSONName)
+`, f.JSONName, f.Name, f.JSONName)
 		}
 	}
 


### PR DESCRIPTION
If you have a json schema with names that have dashes in them and are required, then the checker will try to make go variables like `foo-barReceived = false` which is not allowed.

If you would like to see more tests, please do 
```bash
go mod init github.com/a-h/generate
go mod tidy
go test ./...
```
And iterate until the tests can run and pass