### PR TITLE
Don't strip underscores from package names

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+output.go linguist-generated=false

--- a/output.go
+++ b/output.go
@@ -288,7 +288,6 @@ func outputFieldDescriptionComment(description string, w io.Writer) {
 
 func cleanPackageName(pkg string) string {
 	pkg = strings.Replace(pkg, ".", "", -1)
-	pkg = strings.Replace(pkg, "_", "", -1)
 	pkg = strings.Replace(pkg, "-", "", -1)
 	return pkg
 }


### PR DESCRIPTION
Underscores are valid in Go package names, there's no reason to strip them.  I need output that goes into `underscore_named_packages`; without this patch, I have to fix the generated files with sed to get what I told `schema-generate` to do in the first place.