### PR TITLE
Giving structs that would be generated with the same name distinctive names

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -775,6 +775,42 @@ func TestTypeAliases(t *testing.T) {
 	}
 }
 
+// Test that reusing type names still results in distict structs
+// being generated.  Problems with the implementation may also affect
+// any tests that reference definitions.
+func TestThatReusedNamesRemainDistinctTypes(t *testing.T) {
+	root := &Schema{}
+	root.Title = "RootElement"
+	root.Properties = map[string]*Schema{
+		"property1": {TypeValue: "object", Title: "foo", Properties: map[string]*Schema{"sub": {TypeValue: "object", Properties: map[string]*Schema{"subproperty1": {TypeValue: "integer"}}}}},
+		"property2": {TypeValue: "object", Title: "foo", Properties: map[string]*Schema{"sub": {TypeValue: "object", Properties: map[string]*Schema{"subproperty1": {TypeValue: "string"}}}}},
+	}
+
+	root.Init()
+
+	g := New(root)
+	err := g.CreateTypes()
+	if err != nil {
+		t.Error(err)
+	}
+	results := g.Structs
+	if len(results) != 5 {
+		t.Errorf("Expected 5 results, but got %d results", len(results))
+	}
+	if _, ok := results["Foo"]; !ok {
+		t.Errorf("Expected type Foo, did not find it")
+	}
+	if _, ok := results["Foo2"]; !ok {
+		t.Errorf("Expected type Foo2, did not find it")
+	}
+	if _, ok := results["Sub"]; !ok {
+		t.Errorf("Expected type Sub, did not find it")
+	}
+	if _, ok := results["Sub2"]; !ok {
+		t.Errorf("Expected type Sub2, did not find it")
+	}
+}
+
 // Root is an example of a generated type.
 type Root struct {
 	Name interface{} `json:"name,omitempty"`

--- a/generator_test.go
+++ b/generator_test.go
@@ -811,6 +811,49 @@ func TestThatReusedNamesRemainDistinctTypes(t *testing.T) {
 	}
 }
 
+// Test that a generated name to avoid conflicts doesn't
+// also conflict with another name (so if Foo2 already exists,
+// and two Foos exist, you should have Foo, Foo2, and Foo22).
+func TestReusedConflictingNames(t *testing.T) {
+	root := &Schema{}
+	root.Title = "RootElement"
+	root.Properties = map[string]*Schema{
+		"property1": {TypeValue: "object", Title: "foo2", Properties: map[string]*Schema{"sub": {TypeValue: "object", Properties: map[string]*Schema{"subproperty1": {TypeValue: "integer"}}}}},
+		"property2": {TypeValue: "object", Title: "foo", Properties: map[string]*Schema{"sub": {TypeValue: "object", Properties: map[string]*Schema{"subproperty1": {TypeValue: "string"}}}}},
+		"property3": {TypeValue: "object", Title: "foo", Properties: map[string]*Schema{"sub": {TypeValue: "object", Properties: map[string]*Schema{"subproperty1": {TypeValue: "string"}}}}},
+	}
+
+	root.Init()
+
+	g := New(root)
+	err := g.CreateTypes()
+	if err != nil {
+		t.Error(err)
+	}
+	results := g.Structs
+	if len(results) != 7 {
+		t.Errorf("Expected 7 results, but got %d results", len(results))
+	}
+	if _, ok := results["Foo"]; !ok {
+		t.Errorf("Expected type Foo, did not find it")
+	}
+	if _, ok := results["Foo2"]; !ok {
+		t.Errorf("Expected type Foo2, did not find it")
+	}
+	if _, ok := results["Foo22"]; !ok {
+		t.Errorf("Expected type Foo22, did not find it")
+	}
+	if _, ok := results["Sub"]; !ok {
+		t.Errorf("Expected type Sub, did not find it")
+	}
+	if _, ok := results["Sub2"]; !ok {
+		t.Errorf("Expected type Sub2, did not find it")
+	}
+	if _, ok := results["Sub3"]; !ok {
+		t.Errorf("Expected type Sub3, did not find it")
+	}
+}
+
 // Root is an example of a generated type.
 type Root struct {
 	Name interface{} `json:"name,omitempty"`

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -63,9 +63,6 @@ type Schema struct {
 	// http://json-schema.org/draft-07/json-schema-validation.html#rfc.section.6.4
 	Items *Schema
 
-	// NameCount is the number of times the instance name was encountered across the schema.
-	NameCount int `json:"-" `
-
 	// Parent schema
 	Parent *Schema `json:"-" `
 


### PR DESCRIPTION
Currently, schemas that reuse property names in different places within the document tree will only generate one struct that mixes everything together, a regression from #28 due to some significant refactoring in #55 and onwards.

This adds a fix and a basic unit test.

~~(This will fail to recognize if you've used `foo2`, `foo`, and `foo` yourself; I guess another future patch could repeatedly check for conflicts until landing on an occupied name instead of doing it just once, but I'll have to leave addressing that corner case to another time.)~~ I've addressed this and added a test for it while fixing a missed detection of distinct objects.